### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server for interacting with Sentry. This MCP server provides tools to interact with the Sentry API, allowing AI assistants to retrieve and analyze error data, manage projects, and monitor application performance.
 
+<a href="https://glama.ai/mcp/servers/sfel2251tz">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/sfel2251tz/badge" alt="Sentry Server MCP server" />
+</a>
+
 ## Requirements
 
 - Node.js (v14 or higher)


### PR DESCRIPTION
This PR adds a badge for the [Sentry MCP Server](https://glama.ai/mcp/servers/sfel2251tz) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/sfel2251tz">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/sfel2251tz/badge" alt="Sentry Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.